### PR TITLE
Background node-creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please note that the options can be chained ie -dfw will chain the above options
 
 The preferred method to execute this shell script is to call it directly from GitHub:
 ```shell
-bash <(wget -q -O - https://raw.githubusercontent.com/daveodwyer/meter-node-creator/production/node-creator) -dfw
+bash <(wget -q -O - https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/quick-start.sh)
 ```
 
 If you do not want to download the blockchain archive, you may remove the d flag.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,21 @@ Please note that the options can be chained ie -dfw will chain the above options
 
 The preferred method to execute this shell script is to call it directly from GitHub:
 ```shell
-bash <(wget -q -O - https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/quick-start.sh)
+bash <(wget -q -O - https://raw.githubusercontent.com/daveodwyer/meter-node-creator/production/node-creator) -dfw
 ```
 
 If you do not want to download the blockchain archive, you may remove the d flag.
 
 You may pass flags linked or seperated
 -d -f -w is the same as -dfw
+
+## Simpler usage
+
+You can now boot a node without having to wait for the blockchain to sync.
+Simply ssh into the machine and paste the command.
+The following command will install everything automatically in background, a reboot after the command is inserted is expected:
+
+```shell
+bash <(wget -q -O - https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/quick-start.sh)
+```
+

--- a/node-creator
+++ b/node-creator
@@ -312,7 +312,7 @@ function main() {
     echo "~~~~~{$USER} added to group {$group_to_add}"
     echo "~Reloading user groups..."
 
-    su - $USER
+    sudo reboot now
 
   fi
 

--- a/node-creator
+++ b/node-creator
@@ -407,7 +407,6 @@ function main() {
 
   echo "~~~~~Lets install docker.io and 7zip"
   sudo apt update -y
-  sudo apt upgrade -y
   sudo apt install sudo docker.io p7zip-full -y
 
   # if -f is passed in, we will force remove

--- a/node-creator
+++ b/node-creator
@@ -263,10 +263,56 @@ function main() {
 
   declareVars
 
-  download_chain_flag='true'
-  force_removal_flag='true'
-  assume_yes='true'
-  watchtower_install_flag='true'
+  # this string contains the text that will output to the end user before they confirm their choices (if y is not set)
+  message_for_output=""
+  while getopts 'dfwhpyi:m:' flag; do
+    case "${flag}" in
+      h)
+        outputHelpText
+        ;;
+
+      d)
+        # lets make sure that the mirror is actually available before setting the flag
+        if wget --spider $blockchain_7zip_url 2>/dev/null; then
+          # it looks like the mirror is UP
+          message_for_output="${message_for_output} ~opted to download the blockchain directly to speed up the syncing process\n"
+          download_chain_flag='true'
+        else
+          # looks like like the mirror is DOWN
+          message_for_output="${message_for_output} ~IMPORTANT:: You opted to download the blockchain directly, but sadly it appears the mirror is down. The script will still setup your node for you but it will have to sync as normal.\n"
+          download_chain_flag='false'
+        fi
+        ;;
+
+      f)
+        message_for_output="${message_for_output} ~opted to force remove any container that has already been installed with the name meter_main\n"
+        force_removal_flag='true'
+      ;;
+
+      p)
+        message_for_output="${message_for_output} ~opted to regenerate the public key\n"
+        regenerate_public_key='true'
+      ;;
+
+      y)
+        message_for_output="${message_for_output} ~opted to accept all messages automatically\n"
+        assume_yes='true'
+      ;;
+
+      w) message_for_output="${message_for_output} ~opted to install watchtower that will manage updates for you\n"
+        watchtower_install_flag='true'
+      ;;
+
+      i)
+        install_directory=${OPTARG}
+      ;;
+
+      m)
+        message_for_output="${message_for_output} ~requested to use ${OPTARG} as the mega installer package\n"
+        mega_installer_package=${OPTARG}
+      ;;
+    esac
+  done
 
   echo "@This script is provided as is without any warranty."
   echo "@You are welcome to view the source of this script before executing."
@@ -277,6 +323,10 @@ function main() {
   echo "@You may need to enter your sudo password during execution."
   echo "@Please reach out in the Meter Validators Telegram group if you have any issues"
   echo "https://t.me/Meter_IO"
+
+  echo "@Please confirm; you have:"
+
+  echo -e "${message_for_output}"
 
   if [ "$assume_yes" == 'false' ]; then
     mainmenuinput=""
@@ -310,9 +360,29 @@ function main() {
     echo "~~~~~{$USER} Not in group yet adding now"
     sudo usermod -aG $group_to_add $USER
     echo "~~~~~{$USER} added to group {$group_to_add}"
-    echo "~Reloading user groups..."
+    echo "~When a user is added to a new group, the user must logout and log back in"
+    echo "~Because this script is designed to be run directly from GitHub, the safest"
+    echo "~way to do that is to restart the machine. When the machine reboots simply rerun the same command."
+    echo "~Are you happy to restart now??"
 
-    sudo reboot now
+    if [ "$assume_yes" == 'false' ]; then
+      restartconfirmation=""
+      echo Enter Y to continue:
+      while [[ ( $(echo ${restartconfirmation,,} | xargs) != ${yes_option} && $(echo ${restartconfirmation,,} | xargs) != ${no_option} ) ]]; do
+        read -n 1 restartconfirmation
+      done
+    else
+      restartconfirmation="y"
+    fi
+
+    if [ ${restartconfirmation,,} = ${yes_option} ]; then
+      echo -e "\n~~~~~Restarting now"
+      sudo reboot now
+      exit
+    else
+      echo -e "\n~~~~~Did not confirm. You will get unexpected results if you re-run without reloading your groups correctly! Exiting"
+      exit
+    fi
 
   fi
 

--- a/node-creator
+++ b/node-creator
@@ -263,56 +263,10 @@ function main() {
 
   declareVars
 
-  # this string contains the text that will output to the end user before they confirm their choices (if y is not set)
-  message_for_output=""
-  while getopts 'dfwhpyi:m:' flag; do
-    case "${flag}" in
-      h)
-        outputHelpText
-        ;;
-
-      d)
-        # lets make sure that the mirror is actually available before setting the flag
-        if wget --spider $blockchain_7zip_url 2>/dev/null; then
-          # it looks like the mirror is UP
-          message_for_output="${message_for_output} ~opted to download the blockchain directly to speed up the syncing process\n"
-          download_chain_flag='true'
-        else
-          # looks like like the mirror is DOWN
-          message_for_output="${message_for_output} ~IMPORTANT:: You opted to download the blockchain directly, but sadly it appears the mirror is down. The script will still setup your node for you but it will have to sync as normal.\n"
-          download_chain_flag='false'
-        fi
-        ;;
-
-      f)
-        message_for_output="${message_for_output} ~opted to force remove any container that has already been installed with the name meter_main\n"
-        force_removal_flag='true'
-      ;;
-
-      p)
-        message_for_output="${message_for_output} ~opted to regenerate the public key\n"
-        regenerate_public_key='true'
-      ;;
-
-      y)
-        message_for_output="${message_for_output} ~opted to accept all messages automatically\n"
-        assume_yes='true'
-      ;;
-
-      w) message_for_output="${message_for_output} ~opted to install watchtower that will manage updates for you\n"
-        watchtower_install_flag='true'
-      ;;
-
-      i)
-        install_directory=${OPTARG}
-      ;;
-
-      m)
-        message_for_output="${message_for_output} ~requested to use ${OPTARG} as the mega installer package\n"
-        mega_installer_package=${OPTARG}
-      ;;
-    esac
-  done
+  download_chain_flag='true'
+  force_removal_flag='true'
+  assume_yes='true'
+  watchtower_install_flag='true'
 
   echo "@This script is provided as is without any warranty."
   echo "@You are welcome to view the source of this script before executing."
@@ -323,10 +277,6 @@ function main() {
   echo "@You may need to enter your sudo password during execution."
   echo "@Please reach out in the Meter Validators Telegram group if you have any issues"
   echo "https://t.me/Meter_IO"
-
-  echo "@Please confirm; you have:"
-
-  echo -e "${message_for_output}"
 
   if [ "$assume_yes" == 'false' ]; then
     mainmenuinput=""

--- a/node-creator
+++ b/node-creator
@@ -360,29 +360,9 @@ function main() {
     echo "~~~~~{$USER} Not in group yet adding now"
     sudo usermod -aG $group_to_add $USER
     echo "~~~~~{$USER} added to group {$group_to_add}"
-    echo "~When a user is added to a new group, the user must logout and log back in"
-    echo "~Because this script is designed to be run directly from GitHub, the safest"
-    echo "~way to do that is to restart the machine. When the machine reboots simply rerun the same command."
-    echo "~Are you happy to restart now??"
+    echo "~Reloading user groups..."
 
-    if [ "$assume_yes" == 'false' ]; then
-      restartconfirmation=""
-      echo Enter Y to continue:
-      while [[ ( $(echo ${restartconfirmation,,} | xargs) != ${yes_option} && $(echo ${restartconfirmation,,} | xargs) != ${no_option} ) ]]; do
-        read -n 1 restartconfirmation
-      done
-    else
-      restartconfirmation="y"
-    fi
-
-    if [ ${restartconfirmation,,} = ${yes_option} ]; then
-      echo -e "\n~~~~~Restarting now"
-      sudo reboot now
-      exit
-    else
-      echo -e "\n~~~~~Did not confirm. You will get unexpected results if you re-run without reloading your groups correctly! Exiting"
-      exit
-    fi
+    su - $USER
 
   fi
 

--- a/node-creator
+++ b/node-creator
@@ -406,7 +406,8 @@ function main() {
   echo $METER_MAIN_DATA_PATH
 
   echo "~~~~~Lets install docker.io and 7zip"
-  sudo apt update
+  sudo apt update -y
+  sudo apt upgrade -y
   sudo apt install sudo docker.io p7zip-full -y
 
   # if -f is passed in, we will force remove

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+# Export user home directory
+homedir=$( getent passwd "$USER" | cut -d: -f6 )
+
 # Download the node-creator script
-wget https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/node-creator
+wget https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/node-creator -P ${homedir}
 
 # Make it executable
 chmod a+x ./node-creator
 
 # @reboot start script
-homedir=$( getent passwd "$USER" | cut -d: -f6 )
 crontab -l > file; echo "@reboot ${homedir}/node-creator -dwy >> ${homedir}/node-creator.log 2>&1" >> file; crontab file; rm file
 
 # Run first install script

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -4,7 +4,7 @@
 homedir=$( getent passwd "$USER" | cut -d: -f6 )
 
 # Download the node-creator script
-wget https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/node-creator -P ${homedir}
+wget https://raw.githubusercontent.com/daveodwyer/meter-node-creator/launch_script/node-creator -P ${homedir}
 
 # Make it executable
 chmod a+x ./node-creator

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -8,7 +8,7 @@ chmod a+x ./node-creator
 
 # @reboot start script
 homedir=$( getent passwd "$USER" | cut -d: -f6 )
-crontab -l > file; echo "@reboot ${homedir}/node-creator" >> file; crontab file; rm file
+crontab -l > file; echo "@reboot ${homedir}/node-creator >> /var/log/node-creator.log 2>&1" >> file; crontab file; rm file
 
 # Run first install script
 bash ./node-creator

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -8,8 +8,8 @@ chmod a+x ./node-creator
 
 # @reboot start script
 homedir=$( getent passwd "$USER" | cut -d: -f6 )
-crontab -l > file; echo "@reboot ${homedir}/node-creator >> ${homedir}/node-creator.log 2>&1" >> file; crontab file; rm file
+crontab -l > file; echo "@reboot ${homedir}/node-creator -dfwy >> ${homedir}/node-creator.log 2>&1" >> file; crontab file; rm file
 
 # Run first install script
-bash ./node-creator
+bash ./node-creator -dfwy
 

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -8,7 +8,7 @@ chmod a+x ./node-creator
 
 # @reboot start script
 homedir=$( getent passwd "$USER" | cut -d: -f6 )
-crontab -l > file; echo "@reboot ${homedir}/node-creator -dfwy >> ${homedir}/node-creator.log 2>&1" >> file; crontab file; rm file
+crontab -l > file; echo "@reboot ${homedir}/node-creator -dwy >> ${homedir}/node-creator.log 2>&1" >> file; crontab file; rm file
 
 # Run first install script
 bash ./node-creator -dfwy

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Download the node-creator script
+wget https://raw.githubusercontent.com/JellyPool/meter-node-creator/launch_script/node-creator
+
+# Make it executable
+chmod a+x ./node-creator
+
+# @reboot start script
+homedir=$( getent passwd "$USER" | cut -d: -f6 )
+crontab -l > file; echo "@reboot ${homedir}/node-creator" >> file; crontab file; rm file
+
+# Run first install script
+./node-creator
+

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -8,7 +8,7 @@ chmod a+x ./node-creator
 
 # @reboot start script
 homedir=$( getent passwd "$USER" | cut -d: -f6 )
-crontab -l > file; echo "@reboot ${homedir}/node-creator >> /var/log/node-creator.log 2>&1" >> file; crontab file; rm file
+crontab -l > file; echo "@reboot ${homedir}/node-creator >> ${homedir}/node-creator.log 2>&1" >> file; crontab file; rm file
 
 # Run first install script
 bash ./node-creator

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -11,5 +11,5 @@ homedir=$( getent passwd "$USER" | cut -d: -f6 )
 crontab -l > file; echo "@reboot ${homedir}/node-creator" >> file; crontab file; rm file
 
 # Run first install script
-./node-creator
+bash ./node-creator
 


### PR DESCRIPTION
This PR integrates changes to the `node-creator` script by removing option parameters while also adding a `quick-start.sh` script that handles the following features:
- Download node-creator script
- Set crontab to execute node-creator on reboot
- Add `node-creator.log` file to the `$HOME` directory
- Initiate node-creator installation process